### PR TITLE
Fix malformed Apple Store URLs in navigation and product sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
                         <li class="group"><a href="https://www.apple.com/entertainment/"
                                 class="font-normal transition duration-500 ease-out group-hover:text-white">Entertainment</a>
                         </li>
-                        <li class="group"><a href="https://www.apple.com/us/shop/got text-smo/buy_accessories"
+                        <li class="group"><a href="https://www.apple.com/us/shop/goto/buy_accessories"
                                 class="font-normal transition duration-500 ease-out group-hover:text-white">Accessories</a>
                         </li>
                         <li class="group"><a href="https://support.apple.com/?cid=gn-ols-home-hp-tab"
@@ -116,7 +116,7 @@
                     <a href="https://www.apple.com/iphone-15-pro/"
                         class="bg-bg-button hover:bg-bg-button-hover px-[15px] py-[7px] rounded-full md:button-md text-sm">Learn
                         more</a>
-                    <a href="https://www.apple.com/sho text-smp/buy-iphone/iphone-15-pro"
+                    <a href="https://www.apple.com/shop/buy-iphone/iphone-15-pro"
                         class="ml-5 border border-bg-button hover:text-white hover:bg-bg-button px-[15px] py-[7px] rounded-full text-bg-button md:button-md text-sm">Buy</a>
                 </div>
             </div>
@@ -141,9 +141,9 @@
                             more</a>
                     </div>
                     <div class="flex items-center">
-                        <a href="https://www.apple.com/us/shop/got text-smo/buy_iphone/iphone_15"
-                            class="ml-5 border border-bg-button hover:text-white hover:bg-bg-button px-[15px] py-[7px] rounded-full text-bg-button md:button-md text-sm">Buy</a>
-                    </div>
+                        <a href="https://www.apple.com/us/shop/goto/buy_iphone/iphone_15"
+                                class="ml-5 border border-bg-button hover:text-white hover:bg-bg-button px-[15px] py-[7px] rounded-full text-bg-button md:button-md text-sm">Buy</a>
+                        </div>
                 </div>
             </div>
         </section>
@@ -160,7 +160,7 @@
                             class="bg-bg-button hover:bg-bg-button-hover px-[15px] py-[7px] rounded-full md:button-md text-sm">Learn more</a>
                     </div>
                     <div class="flex items-center ">
-                            <a href="https://www.apple.com/us/shop/got text-smo/buy_mac/macbook_air"
+                            <a href="https://www.apple.com/us/shop/goto/buy_mac/macbook_air"
                                 class="ml-5 border border-bg-button hover:text-white hover:bg-bg-button px-[15px] py-[7px] rounded-full text-bg-button md:button-md text-sm">Buy</a>
                     </div>
                 </div>
@@ -204,7 +204,7 @@
                                                 <a href="https://www.apple.com/apple-vision-pro/"
                                                     class="bg-bg-button hover:bg-bg-button-hover min-[832px]:text-[14px] px-[15px] py-[7px] rounded-full  text-sm">Learn
                                                     more</a>
-                                                <a href="https://www.apple.com/us/shop/got text-smo/buy_vision/apple_vision_pro"
+                                                <a href="https://www.apple.com/us/shop/goto/buy_vision/apple_vision_pro"
                                                     class="ml-5 border border-bg-button hover:text-white hover:bg-bg-button px-[15px] py-[7px] rounded-full text-bg-button  min-[832px]:text-[14px] text-sm">Buy</a>
                                             </div>
                                         </div>
@@ -226,7 +226,7 @@
                                                 <a href="https://www.apple.com/apple-watch-series-9/"
                                                     class="bg-bg-button hover:bg-bg-button-hover min-[832px]:text-[14px] px-[15px] py-[7px] rounded-full  text-sm">Learn
                                                     more</a>
-                                                <a href="https://www.apple.com/us/shop/got min-[832px]:text-[14px] text-smo/buy_watch/apple_watch_series_9"
+                                                <a href="https://www.apple.com/us/shop/goto/buy_watch/apple_watch_series_9"
                                                     class="ml-5 border border-bg-button hover:text-white hover:bg-bg-button px-[15px] py-[7px] rounded-full text-bg-button min-[832px]:text-[14px] text-sm">Buy</a>
                                             </div>
                                         </div>
@@ -505,11 +505,11 @@
                                                 </li>
                                                 <li
                                                     class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
-                                                    <a href="https://www.apple.com/us/shop/got text-smo/buy_accessories"
+                                                    <a href="https://www.apple.com/us/shop/goto/buy_accessories"
                                                         class="group-hover:underline">Accessories</a>
-                                                </li>
-                                                <li
-                                                    class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
+                                                    </li>
+                                                    <li
+                                                        class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
                                                     <a href="https://www.apple.com/us/shop/goto/giftcards"
                                                         class="group-hover:underline">Gift Cards</a>
                                                 </li>
@@ -715,11 +715,11 @@
                                                 </li>
                                                 <li
                                                     class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
-                                                    <a href="https://www.apple.com/us/shop/got text-smo/buy_iphone/carrier_offers"
+                                                    <a href="https://www.apple.com/us/shop/goto/buy_iphone/carrier_offers"
                                                         class="group-hover:underline">Carrier Deals at Apple</a>
-                                                </li>
-                                                <li
-                                                    class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
+                                                    </li>
+                                                    <li
+                                                        class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
                                                     <a href="https://www.apple.com/us/shop/goto/order/list"
                                                         class="group-hover:underline">Order Status</a>
                                                 </li>
@@ -785,11 +785,11 @@
                                                 </li>
                                                 <li
                                                     class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
-                                                    <a href="https://www.apple.com/education/k12/how-t text-smo-buy/"
+                                                    <a href="https://www.apple.com/education/k12/how-to-buy/"
                                                         class="group-hover:underline">Shop for K-12</a>
-                                                </li>
-                                                <li
-                                                    class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
+                                                    </li>
+                                                    <li
+                                                        class="py-[6px] px-[14px] min-[832px]:mb-[10px] min-[832px]:p-0 w-full group cursor-pointer min-[832px]:cursor-default">
                                                     <a href="https://www.apple.com/us/shop/goto/educationrouting"
                                                         class="group-hover:underline">Shop for Students</a>
                                                 </li>


### PR DESCRIPTION
## Summary
- Correct navigation Accessories link pointing to Apple Store buy_accessories
- Repair product buy links for iPhone 15 Pro, iPhone 15, MacBook Air, Apple Watch Series 9, Vision Pro, and carrier deals
- Remove stray CSS tokens from K-12 education link

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a67652d9bc8327ad5fd434bbf7ea57